### PR TITLE
Update Flux CLI command in README.md

### DIFF
--- a/IMAGE_UPDATES_README.md
+++ b/IMAGE_UPDATES_README.md
@@ -1,0 +1,30 @@
+# Image Updates
+
+The objective of this lab is to demonstrate how to use FluxCD to automate image updates in a Kubernetes cluster. The lab will use the [AKS Store Demo](https://github.com/Azure-Samples/aks-store-demo) application as an example.
+
+The intended workflow:
+1. Modify application code, then commit and push the change to the repo.
+2. Create a new release in GitHub which kicks off a release workflow to build and push an updated container image to a GitHub Container Registry.
+3. FluxCD detects the new image and updates the image tag in the cluster.
+4. FluxCD rolls out the new image to the cluster.
+
+## Bootstrapping FluxCD
+
+In the first sectionI used the AKS extension to install FluxCD. In this section I will use the Flux CLI to install FluxCD. This will enable us to have a bit more control over the installation and gives the ability yo save Flux resources in the repo.
+
+Navigate to the manifest folder and set the following environment variables:
+
+```bash
+cd manifests
+$ghUser=$(gh api user --jq .login)
+ 
+$ghToken=$(gh auth token) 
+```
+
+Now we're ready to bootstrap FluxCD. Run the following command to bootstrap FluxCD. This command will install FluxCD with additional components to enable image automation. It will also generate the Flux resources and commit them to our Git repo in the clusters/dev directory.
+
+```bash
+echo $ghToken | flux bootstrap github create --owner=$ghUser --repository=gitops --personal --path=./clusters/dev --branch=main --reconcile --network-policy --components-extra=image-reflector-controller,image-automation-controller
+```
+
+After a few minutes, run the following commands and you should see the Flux resources in the repo.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ az k8s-extension create --cluster-name $aksClusterName --resource-group $rgName 
 With the extension installed, you can run the following Flux CLI command to get the status of the installation.
 
 ```bash
-flux check
+flux check --pre
 ```
 
 Flux installs many new Custom Resource Definitions (CRDs) in the cluster. These CRDs are how you interact with FluxCD. You can run the following command to see all the new CRDs
@@ -183,3 +183,44 @@ git diff overlays/dev/kustomization.yaml
 ```
 
 Add the change, commit, and push to GitHub.
+
+Using the Flux CLI, you can force FluxCD to reconcile the cluster with the desired state defined in the repo.
+
+```bash
+flux reconcile kustomization aks-store-demo-dev --with-source
+```
+
+fter a minute or two you should see the pods coming online in the new dev namespace. This is FluxCD reconciling the cluster with the desired state defined in the repo.
+
+You can check on the pods using the following command.
+
+```bash
+kubectl get pods -n dev
+```
+
+## Monitoring and Troubleshooting
+
+Some tips when it comes to monitoring and troubleshooting Flux resources is to use the Flux CLI. You can use some of these basic commands to get information about Flux and its resources:
+
+```bash
+# check the status of the flux installation
+flux check
+
+# get info about the GitRepository resource
+flux get source git aks-store-demo-dev -n flux-system
+
+# get info about the Kustomization resource
+flux get kustomization aks-store-demo-dev -n flux-system
+
+# view event logs from the flux controllers
+flux events
+
+# view logs from the flux controllers
+flux log
+
+# view stats of the flux controllers
+flux stats
+```
+
+This showed the setup of FluxCD AKS Extension and how to use it to deploy applications to AKS cluster. Now we will move a bit deeper and how to use FluxCD to automate images updates.
+[Image updates](./IMAGE_UPDATES_README.md)


### PR DESCRIPTION
This pull request enhances the documentation for using the Flux CLI and automating image updates with FluxCD in a Kubernetes cluster. The most important changes include adding additional instructions to the `README.md` file, modifying the command for checking the status of the Flux installation, and adding a new section to `IMAGE_UPDATES_README.md` explaining the lab objective and workflow.

Documentation improvements:

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R186-R226">`README.md`</a>: Added additional instructions for using the Flux CLI to reconcile the cluster with the desired state and provided tips for monitoring and troubleshooting Flux resources. Modified the command for checking the status of the Flux installation by adding the `--pre` flag to the `flux check` command. <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R186-R226">[1]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R57">[2]</a>
* <a href="diffhunk://#diff-dc714b97b27bbebbc44532268d4453bbe2a5c2a81367e10b7e0bf6ae201426ecR1-R30">`IMAGE_UPDATES_README.md`</a>: Added a new section explaining the lab objective and workflow for using FluxCD to automate image updates in a Kubernetes cluster.