### PR TITLE
Update dev overlay namespace to "dev"

### DIFF
--- a/overlays/dev/kustomization.yaml
+++ b/overlays/dev/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
 - namespace.yaml
 - ./../../manifests
-namespace: myapp-dev
+namespace: dev


### PR DESCRIPTION
This pull request includes changes related to deployment and configuration instructions. The most important changes include updating the `namespace` value in the `overlays/dev/kustomization.yaml` file and adding detailed instructions to the `README.md` file on deploying applications using FluxCD and configuring the FluxCD AKS extension.

Deployment and configuration changes:

* [`overlays/dev/kustomization.yaml`](diffhunk://#diff-ff92d00b9d45f9dea34156a41835ad8e39e6af3b827e4bf0b1bbfce2b6a543f4L6-R6): Changed the `namespace` value from `myapp-dev` to `dev`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R246-R299): Added instructions on deploying applications using FluxCD and configuring the FluxCD AKS extension. Also included instructions on creating Flux `GitRepository` and `Kustomization` resources in the `flux-system` namespace.